### PR TITLE
Add Makefile that sets up the environment for specific es versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ htmlcov/
 data/
 config.yaml
 my_account_iam.json
+requirements-dev.es[0-9].txt
+requirements.es[0-9].txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+SHELL := /bin/bash
+
+SUPPORTED_VERSIONS=1 6
+DEV_TARGETS = $(addprefix dev_elasticsearchv,${SUPPORTED_VERSIONS})
+
+.PHONY: requirements_es1
+requirements_es1: requirements.txt requirements-dev.txt
+	@sed -e 's/^elasticsearch==\(.*$$\)/elasticsearch==1.9.0/g' requirements.txt | sed -e 's/^elasticsearch_dsl==\(.*$$\)/elasticsearch_dsl==0.0.11/g' > requirements.es1.txt
+	@sed -e 's/requirements\.txt/requirements.es1.txt/g' requirements-dev.txt > requirements-dev.es1.txt
+
+.PHONY: requirements_es6
+requirements_es6: requirements.txt requirements-dev.txt
+	@cp requirements.txt requirements.es6.txt
+	@cp requirements-dev.txt requirements-dev.es6.txt
+
+.PHONY: ${DEV_TARGETS}
+${DEV_TARGETS}: dev_elasticsearchv%: requirements_es%
+	@( \
+		test -d ./venv || virtualenv ./venv; \
+		. ./venv/bin/activate; \
+		pip install --upgrade pip; \
+		pip install -r requirements-dev.es$*.txt; \
+	)
+	@echo
+	@echo "** You have configured your environment for elasticsearch v$* **"
+	@echo '** Now you should `source ./venv/bin/activate` to activate your virtualenv **'
+	@echo
+
+.PHONY: clean
+clean:
+	@rm -rf ./venv
+	@ls -1 | grep -P "requirements(-)?(dev)?\.es\d\.txt" | xargs

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 	# Delete the virtual environment
 	@rm -rf ./venv
 	# Get rid of any generated requirements.txt files
-	@ls -1 | grep -P "requirements(-)?(dev)?\.es\d\.txt" | xargs
+	@rm ./requirements*es*.txt
 
 help:
 	@printf "\033[36m%-20s\033[0m %s\n" "dev_elasticsearchv1" "Configures the environment for es v1"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+.DEFAULT_GOAL := help
 
 SUPPORTED_VERSIONS=1 6
 DEV_TARGETS = $(addprefix dev_elasticsearchv,${SUPPORTED_VERSIONS})
@@ -36,3 +36,8 @@ clean:
 	@rm -rf ./venv
 	# Get rid of any generated requirements.txt files
 	@ls -1 | grep -P "requirements(-)?(dev)?\.es\d\.txt" | xargs
+
+help:
+	@printf "\033[36m%-20s\033[0m %s\n" "dev_elasticsearchv1" "Configures the environment for es v1"
+	@printf "\033[36m%-20s\033[0m %s\n" "dev_elasticsearchv6" "Configures the environment for es v6"
+	@printf "\033[36m%-20s\033[0m %s\n" "clean" "Clean build artifacts"

--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,15 @@ DEV_TARGETS = $(addprefix dev_elasticsearchv,${SUPPORTED_VERSIONS})
 
 .PHONY: requirements_es1
 requirements_es1: requirements.txt requirements-dev.txt
+	# Replace the default elasticsearch versions with the ones that work with es v1.x
+	# Create new files on disk that refer to the custom versions
 	@sed -e 's/^elasticsearch==\(.*$$\)/elasticsearch==1.9.0/g' requirements.txt | sed -e 's/^elasticsearch_dsl==\(.*$$\)/elasticsearch_dsl==0.0.11/g' > requirements.es1.txt
 	@sed -e 's/requirements\.txt/requirements.es1.txt/g' requirements-dev.txt > requirements-dev.es1.txt
 
 .PHONY: requirements_es6
 requirements_es6: requirements.txt requirements-dev.txt
+	# Since es6 is the default, no need to make any changes
+	# But make a copy so that the dev_elasticsearchv6 can be left generic
 	@cp requirements.txt requirements.es6.txt
 	@cp requirements-dev.txt requirements-dev.es6.txt
 
@@ -28,5 +32,7 @@ ${DEV_TARGETS}: dev_elasticsearchv%: requirements_es%
 
 .PHONY: clean
 clean:
+	# Delete the virtual environment
 	@rm -rf ./venv
+	# Get rid of any generated requirements.txt files
 	@ls -1 | grep -P "requirements(-)?(dev)?\.es\d\.txt" | xargs

--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@ Installation
 CloudTracker requires you to have loaded CloudTrail logs into ElasticSearch.  For instructions on setting up ElasticSearch and ingesting an archive of CloudTrail logs into it see [ElasticSearch installation and ingestion](docs/elasticsearch.md)
 
 ### Step 1
-Install the Python libraries:
+Install the Python libraries using one of the provided Makefile targets:
+
+For elasticsearch v6.x:
 ```
-git clone https://github.com/duo-labs/cloudtracker.git
-cd cloudtracker
-virtualenv venv
+make dev_elasticsearchv6
 source venv/bin/activate
-pip install -r requirements.txt
 ```
+
+For older versions, such as elasticsearch v1.x:
+```
+make dev_elasticsearchv1
+source venv/bin/activate
+```
+The target will create a virtualenv in `./venv` and pip install the relevant requirements.
 
 ### Step 2
 Get the IAM data of the account

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,4 @@
-elasticsearch==6.1.1
-elasticsearch_dsl==6.1.0
-pyyaml==3.12
-pyjq==2.1.0
-ansicolors==1.1.8
+-r requirements.txt
 autoflake==0.7
 autopep8==1.3.1
 nose==1.3.7


### PR DESCRIPTION
This Makefile aims to simplify setup for end users who might have different versions of elasticsearch clusters that house their cloudtrail data.