### PR TITLE
Quiet flag for ignoring status messages

### DIFF
--- a/cloudtracker/__init__.py
+++ b/cloudtracker/__init__.py
@@ -463,11 +463,13 @@ def run(args, config, start, end):
             username = args.user
 
             user_iam = get_user_iam(username, account_iam)
-            print("Getting info on {}, user created {}".format(args.user, user_iam['CreateDate']))
+            if not args.quiet:
+                print("Getting info on {}, user created {}".format(args.user, user_iam['CreateDate']))
 
             if args.destrole:
                 dest_role_iam = get_role_iam(args.destrole, destination_iam)
-                print("Getting info for AssumeRole into {}".format(args.destrole))
+                if not args.quiet:
+                    print("Getting info for AssumeRole into {}".format(args.destrole))
 
                 allowed_actions = get_role_allowed_actions(aws_api_list, dest_role_iam, destination_iam)
                 performed_actions = datasource.get_performed_event_names_by_user_in_role(
@@ -479,11 +481,13 @@ def run(args, config, start, end):
         elif args.role:
             rolename = args.role
             role_iam = get_role_iam(rolename, account_iam)
-            print("Getting info for role {}".format(rolename))
+            if not args.quiet:
+                print("Getting info for role {}".format(rolename))
 
             if args.destrole:
                 dest_role_iam = get_role_iam(args.destrole, destination_iam)
-                print("Getting info for AssumeRole into {}".format(args.destrole))
+                if not args.quiet:
+                    print("Getting info for AssumeRole into {}".format(args.destrole))
 
                 allowed_actions = get_role_allowed_actions(aws_api_list, dest_role_iam, destination_iam)
                 performed_actions = datasource.get_performed_event_names_by_role_in_role(

--- a/cloudtracker/cli.py
+++ b/cloudtracker/cli.py
@@ -89,6 +89,7 @@ def main():
     parser.add_argument("--skip-setup", dest='skip_setup',
                         help="For Athena, don't create or test for the tables",
                         required=False, action='store_true', default=False)
+    parser.add_argument("--quiet", help="Only display the output", required=False, action='store_true')
 
     args = parser.parse_args()
 

--- a/cloudtracker/datasources/athena.py
+++ b/cloudtracker/datasources/athena.py
@@ -140,6 +140,9 @@ class Athena(object):
     def __init__(self, config, account, start, end, args):
         # Mute boto except errors
         logging.getLogger('botocore').setLevel(logging.WARN)
+        if args.quiet:
+            logging.getLogger().setLevel(logging.CRITICAL)
+
         logging.info('Source of CloudTrail logs: s3://{bucket}/{path}'.format(
             bucket=config['s3_bucket'],
             path=config['path']))


### PR DESCRIPTION
added simple 'quiet' flag to only output the results and ignore the status messages. Makes it easier to use cloudtracker for automated reporting. 