### PR TITLE
Upgrade requirements

### DIFF
--- a/config.yaml.demo
+++ b/config.yaml.demo
@@ -11,4 +11,4 @@ accounts:
     iam: account-data/demo_iam.json
   - name: demo2
     id: 222222222222
-    iam: account-data/demo2_iam.json 
+    iam: account-data/demo2_iam.json

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
     },
     install_requires=[
         'ansicolors==1.1.8',
-        'boto3==1.5.32',
-        'jmespath==0.9.3',
-        'pyyaml==4.2b4'
+        'boto3==1.9.202',
+        'jmespath==0.9.4',
+        'PyYAML==5.1.2'
     ],
     setup_requires=['nose'],
     packages=find_packages(exclude=['tests*']),


### PR DESCRIPTION
## Issue

I hit the following error when trying to install CloudTracker via `pip`:

```bash
$ python -V
Python 3.7.2

pip install cloudtracker
...
Building wheels for collected packages: pyyaml
  Building wheel for pyyaml (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /Users/nkraus/.virtualenvs/cloudtracker/bin/python3.7 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/sd/nmgrfczd6lq2j59x
jg7yc37j5ppjz1/T/pip-install-_fmp6z5a/pyyaml/setup.py'"'"'; __file__='"'"'/private/var/folders/sd/nmgrfczd6lq2j59xjg7yc37j5ppjz1/T/pip-install-_fmp6z5a/pyyaml/setup.p
y'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))
' bdist_wheel -d /private/var/folders/sd/nmgrfczd6lq2j59xjg7yc37j5ppjz1/T/pip-wheel-sq3f00_j --python-tag cp37
       cwd: /private/var/folders/sd/nmgrfczd6lq2j59xjg7yc37j5ppjz1/T/pip-install-_fmp6z5a/pyyaml/
```

## Solution
Bumping the requirements seems to have fixed the issue:

```bash
$ pip install -e .
...
Successfully installed PyYAML-5.1.2 boto3-1.9.202 botocore-1.12.202 cloudtracker docutils-0.14 jmespath-0.9.4 s3transfer-0.2.1 urllib3-1.25.3
```

## Testing

Ran Nosetests:

```bash
$ nosetests tests/unit/test_cloudtracker.py
...........
Name                       Stmts   Miss  Cover
----------------------------------------------
cloudtracker/__init__.py     271    129    52%
----------------------------------------------------------------------
Ran 11 tests in 0.229s

OK
```