### PR TITLE
Allow for org-id to be configured (#46)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ accounts:
 This assumes your CloudTrail logs are at `s3://my_log_bucket/my_prefix/AWSLogs/111111111111/CloudTrail/`
 Set `my_prefix` to `''` if you have no prefix.
 
+If your CloudTrail is managed through an organisation you can configure this in the `athena` section:
+
+```
+athena:
+  s3_bucket: my_log_bucket
+  path: my_prefix
+  org_id: o-myid123
+```
+
 ### Step 4: Run CloudTracker
 
 CloudTracker uses boto and assumes it has access to AWS credentials in environment variables, which can be done by using [aws-vault](https://github.com/99designs/aws-vault).

--- a/cloudtracker/datasources/athena.py
+++ b/cloudtracker/datasources/athena.py
@@ -228,9 +228,15 @@ class Athena(object):
                 current_account_id, region
             )
         logging.info("Using output bucket: {}".format(self.output_bucket))
-        cloudtrail_log_path = "s3://{bucket}/{path}/AWSLogs/{account_id}/CloudTrail".format(
-            bucket=config["s3_bucket"], path=config["path"], account_id=account["id"]
-        )
+        if not config.get('org_id'):
+            cloudtrail_log_path = "s3://{bucket}/{path}/AWSLogs/{account_id}/CloudTrail".format(
+                bucket=config["s3_bucket"], path=config["path"], account_id=account["id"]
+            )
+        else:
+            cloudtrail_log_path = "s3://{bucket}/{path}/AWSLogs/{org_id}/{account_id}/CloudTrail".format(
+                bucket=config["s3_bucket"], path=config["path"], org_id=config["org_id"], account_id=account["id"]
+            )
+
         logging.info("Account cloudtrail log path: {}".format(cloudtrail_log_path))
 
         # Open connections to needed AWS services


### PR DESCRIPTION
Note this is the quickest fix possible. In my setup all logs are under one org-id so it made sense there but I could change it to be per-account. Let me know if you'd like me to make changes.